### PR TITLE
お店登録画面で登録した電話番号をCoreDataで管理する

### DIFF
--- a/GourmeListApp/GourmeListApp.xcodeproj/project.pbxproj
+++ b/GourmeListApp/GourmeListApp.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"GourmeListApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = A3RFT222AP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -511,7 +511,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"GourmeListApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = A3RFT222AP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/GourmeListApp/GourmeListApp/GourmeListApp.xcdatamodeld/PhotoCoreData.xcdatamodel/contents
+++ b/GourmeListApp/GourmeListApp/GourmeListApp.xcdatamodeld/PhotoCoreData.xcdatamodel/contents
@@ -6,6 +6,7 @@
         <attribute name="fileName" optional="YES" attributeType="String"/>
         <attribute name="memo" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String"/>
         <attribute name="visitDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
 </model>

--- a/GourmeListApp/GourmeListApp/Persistence.swift
+++ b/GourmeListApp/GourmeListApp/Persistence.swift
@@ -20,6 +20,7 @@ struct PersistenceController {
             newStores.visitDate = Date()
             newStores.memo = "testMemo"
             newStores.businessHours = "年中無休"
+            newStores.phoneNumber = "000-0000-000"
             newStores.address = "東京都新宿区新宿39"
         }
         do {

--- a/GourmeListApp/GourmeListApp/View/StoreRegistrationView.swift
+++ b/GourmeListApp/GourmeListApp/View/StoreRegistrationView.swift
@@ -29,7 +29,7 @@ struct StoreRegistrationView: View {
     @State private var isTagSelectionVisible: Bool = false
     // 画像削除時のアラート表示
     @State private var isDeleteImageAlertVisible: Bool = false
-    
+
     var body: some View {
         NavigationStack {
             Spacer()
@@ -47,12 +47,12 @@ struct StoreRegistrationView: View {
                                     // フォトピッカーを表示するView
                                     PhotosPicker(selection: $viewModel.registrationViewDetailData.selectedItems, selectionBehavior: .ordered) {
                                         Image(uiImage: image)
-                                        // 画像サイズを変更可能にする
+                                            // 画像サイズを変更可能にする
                                             .resizable()
-                                        //  アスペクト比を維持しながら指定されたフレームを埋める
+                                            //  アスペクト比を維持しながら指定されたフレームを埋める
                                             .scaledToFill()
                                             .frame(width: 120, height: 80)
-                                        // フレームからはみ出た部分を切り取る
+                                            // フレームからはみ出た部分を切り取る
                                             .clipped()
                                             .padding(5)
                                     }
@@ -94,7 +94,7 @@ struct StoreRegistrationView: View {
                             .storeInfoTextStyle()
                         // 店名を記載するスペース
                         TextField("", text: $viewModel.registrationViewDetailData.storeName)
-                        // 最大幅
+                            // 最大幅
                             .frame(maxWidth: .infinity)
                         //　虫眼鏡
                         Button(action: {
@@ -154,7 +154,7 @@ struct StoreRegistrationView: View {
                             borderColor: .gray,
                             borderWidth: 1
                         )
-                    // プレースホルダーを追加
+                        // プレースホルダーを追加
                         .overlay(alignment: .center) {
                             // 未入力時、プレースホルダーを表示
                             if viewModel.registrationViewDetailData.memo.isEmpty {
@@ -170,7 +170,7 @@ struct StoreRegistrationView: View {
                             borderColor: .gray,
                             borderWidth: 1
                         )
-                    // プレースホルダーを追加
+                        // プレースホルダーを追加
                         .overlay(alignment: .center) {
                             // 未入力時、プレースホルダーを表示
                             if viewModel.registrationViewDetailData.businessHours.isEmpty {
@@ -186,6 +186,8 @@ struct StoreRegistrationView: View {
                             .storeInfoTextStyle()
                         // 電話番号欄
                         TextField("", text: $viewModel.registrationViewDetailData.phoneNumber)
+                            // 電話番号入力タイプのキーボード
+                            .keyboardType(.phonePad)
                     }
                     Divider()
                     HStack {
@@ -193,7 +195,7 @@ struct StoreRegistrationView: View {
                         Text("住所")
                             .storeInfoTextStyle()
                         TextField("", text: $viewModel.registrationViewDetailData.address)
-                        // 入力完了直後に住所を検索
+                            // 入力完了直後に住所を検索
                             .onSubmit {
                                 viewModel.searchAddress()
                             }
@@ -227,20 +229,20 @@ struct StoreRegistrationView: View {
                 // 訪問日画面を表示する際の設定
                 .sheet(isPresented: $isVisitDateVisible) {
                     VisitDateView(visitDate: $viewModel.registrationViewDetailData.visitDate)
-                    // シートの高さをカスタマイズ
+                        // シートの高さをカスタマイズ
                         .presentationDetents([.height(280)])
                 }
                 // タグ選択画面を表示する際の設定
                 .sheet(isPresented: $isTagSelectionVisible) {
                     // タグ追加画面を表示
                     TagAddView()
-                    // ハーフモーダルで表示。全画面とハーフに可変できるようにする。
+                        // ハーフモーダルで表示。全画面とハーフに可変できるようにする。
                         .presentationDetents([
                             .medium,
                             .large
                         ])
                 }
-                
+
             }
             // NavigationBarを固定する
             .navigationBarTitleDisplayMode(.inline)
@@ -274,6 +276,8 @@ struct StoreRegistrationView: View {
                         viewModel.addMemo(viewContext: viewContext)
                         // 営業時間をCoreDataに保存
                         viewModel.addBusinessHours(viewContext: viewContext)
+                        // 電話番号をCoreDataに保存
+                        viewModel.addPhoneNumber(viewContext: viewContext)
                         // 住所をCoreDataに保存
                         viewModel.addAddress(viewContext: viewContext)
                         // ホーム画面に遷移

--- a/GourmeListApp/GourmeListApp/ViewModel/StoreEditViewModel.swift
+++ b/GourmeListApp/GourmeListApp/ViewModel/StoreEditViewModel.swift
@@ -12,7 +12,7 @@ import CoreData
 class StoreEditViewModel: ObservableObject {
     // @Published:ObservedObjectプロパティに準拠したクラス内部のプロパティを監視し、複数のviewに対して自動通知を行うことができる
     @Published var editViewDetailData: StoreDetailData = StoreDetailData(selectedItems: [], selectedImages: [], selectedIndexes: [], storeName: "", visitStatusTag: 0, visitDate: Date(), memo: "", businessHours: "", phoneNumber: "", address: "", selectedLocation: nil, position: .automatic)
-    
+
     // 非同期かつ、メインスレッド上でUIImageへの変換処理を行う関数
     @MainActor func loadSelectedImages(items: [PhotosPickerItem]) async {
         // 一時的にUIImageデータを格納する配列
@@ -41,7 +41,7 @@ class StoreEditViewModel: ObservableObject {
         let uuid = UUID().uuidString
         // 生成したuuidをファイル名に使用
         let fileName = "\(uuid).png"
-        
+
         // 画像をpngデータに変換
         guard let data = image.pngData() else {
             return nil
@@ -53,7 +53,7 @@ class StoreEditViewModel: ObservableObject {
         }
         // 保存するファイルのフルパスを作成
         let fileURL = documentsDirectory.appendingPathComponent(fileName)
-        
+
         // エラーハンドリング処理
         do {
             // データをファイルに書き込む
@@ -81,13 +81,13 @@ class StoreEditViewModel: ObservableObject {
                     newFileNames.append(unwrappedFileName)
                 }
             }
-            
+
             // ファイル名を結合
             let fileNameString = newFileNames.joined(separator: ",")
-            
+
             // 既存のエントリをチェックして、ボタン押下の度に新エントリが作成されるのを防ぐ
             let existingPhoto = fetchedStores.first
-            
+
             // エントリが存在してれば、エントリを更新
             if let photo = existingPhoto {
                 photo.fileName = fileNameString
@@ -96,7 +96,7 @@ class StoreEditViewModel: ObservableObject {
                 let newPhoto = Stores(context: viewContext)
                 newPhoto.fileName = fileNameString
             }
-            
+
             // CoreDataにファイル名を保存する
             do {
                 try viewContext.save()

--- a/GourmeListApp/GourmeListApp/ViewModel/StoreRegistrationViewModel.swift
+++ b/GourmeListApp/GourmeListApp/ViewModel/StoreRegistrationViewModel.swift
@@ -13,7 +13,7 @@ import MapKit
 class StoreRegistrationViewModel: ObservableObject {
     // @Published:ObservedObjectプロパティに準拠したクラス内部のプロパティを監視し、複数のviewに対して自動通知を行うことができる
     @Published var registrationViewDetailData: StoreDetailData = StoreDetailData(selectedItems: [], selectedImages: [], selectedIndexes: [], storeName: "", visitStatusTag: 0, visitDate: Date(), memo: "", businessHours: "", phoneNumber: "", address: "", selectedLocation: nil, position: .automatic)
-    
+
     // 非同期かつ、メインスレッド上でUIImageへの変換処理を行う関数
     @MainActor func loadSelectedImages(items: [PhotosPickerItem]) async {
         // 一時的にUIImageデータを格納する配列
@@ -42,7 +42,7 @@ class StoreRegistrationViewModel: ObservableObject {
         let uuid = UUID().uuidString
         // 生成したuuidをファイル名に使用
         let fileName = "\(uuid).png"
-        
+
         // 画像をpngデータに変換
         guard let data = image.pngData() else {
             return nil
@@ -54,7 +54,7 @@ class StoreRegistrationViewModel: ObservableObject {
         }
         // 保存するファイルのフルパスを作成
         let fileURL = documentsDirectory.appendingPathComponent(fileName)
-        
+
         // エラーハンドリング処理
         do {
             // データをファイルに書き込む
@@ -82,13 +82,13 @@ class StoreRegistrationViewModel: ObservableObject {
                     newFileNames.append(unwrappedFileName)
                 }
             }
-            
+
             // ファイル名を結合
             let fileNameString = newFileNames.joined(separator: ",")
-            
+
             // 既存のエントリをチェックして、ボタン押下の度に新エントリが作成されるのを防ぐ
             let existingPhoto = fetchedStores.first
-            
+
             // エントリが存在してれば、エントリを更新
             if let photo = existingPhoto {
                 photo.fileName = fileNameString
@@ -97,7 +97,7 @@ class StoreRegistrationViewModel: ObservableObject {
                 let newPhoto = Stores(context: viewContext)
                 newPhoto.fileName = fileNameString
             }
-            
+
             // CoreDataにファイル名を保存する
             do {
                 try viewContext.save()
@@ -141,7 +141,7 @@ class StoreRegistrationViewModel: ObservableObject {
         let fetchRequest: NSFetchRequest<Stores> = Stores.fetchRequest()
         // Storesエンティティのnameアトリビュートと完全一致するstoreName変数名を検索するNSPredicate を作成
         fetchRequest.predicate = NSPredicate(format: "name == %@", registrationViewDetailData.storeName)
-        
+
         // CoreDataへ保存
         do {
             // 設定したfetchRequestを使用してデータベースからデータを取得
@@ -155,7 +155,7 @@ class StoreRegistrationViewModel: ObservableObject {
             }
             // 店名をStoresEntityのnameAttributeに格納
             store.name = registrationViewDetailData.storeName
-            
+
             try viewContext.save()
             print("CoreData 店名登録完了: \(registrationViewDetailData.storeName)")
         } catch {
@@ -167,7 +167,7 @@ class StoreRegistrationViewModel: ObservableObject {
         let store = Stores(context: viewContext)
         // 入力した日付をStoresEntityのvisitDateAttributeへ格納
         store.visitDate = registrationViewDetailData.visitDate
-        
+
         // CoreDataに保存
         do {
             try viewContext.save()
@@ -180,7 +180,7 @@ class StoreRegistrationViewModel: ObservableObject {
         let store = Stores(context: viewContext)
         // メモ内容をStoresEntityのmemoAttributeに格納
         store.memo = registrationViewDetailData.memo
-        
+
         // CoreDataに保存
         do {
             try viewContext.save()
@@ -194,7 +194,7 @@ class StoreRegistrationViewModel: ObservableObject {
         let store = Stores(context: viewContext)
         // 営業時間の内容をStoresEntityのbusinessHoursAttributeに格納
         store.businessHours = registrationViewDetailData.businessHours
-        
+
         // CoreDataに保存
         do {
             try viewContext.save()
@@ -203,12 +203,26 @@ class StoreRegistrationViewModel: ObservableObject {
             print("CoreData 営業時間ERROR \(error)")
         }
     }
+    // 電話番号の内容を保存する関数
+    func addPhoneNumber(viewContext: NSManagedObjectContext) {
+        let store = Stores(context: viewContext)
+        // 電話番号の内容をStoresEntityのphoneNumberAttributeに格納
+        store.phoneNumber = registrationViewDetailData.phoneNumber
+
+        // CoreDataに保存
+        do {
+            try viewContext.save()
+            print("CoreData 電話番号登録完了: \(registrationViewDetailData.phoneNumber)")
+        } catch {
+            print("CoreData 電話番号ERROR \(error)")
+        }
+    }
     // 住所の内容を保存する関数
     func addAddress(viewContext: NSManagedObjectContext) {
         let store = Stores(context: viewContext)
         // 住所の内容をStoresEntityのaddressAttributeに格納
         store.address = registrationViewDetailData.address
-        
+
         // CoreDataに保存
         do {
             try viewContext.save()


### PR DESCRIPTION
<!-- Issueのテンプレートです。入力できるところを埋めてください。 -->
<!-- 記入しない項目は特になしと記入してください。。 -->

<!-- 関連Isuueを記載してください。close #の後にIssue番号を記載すると連携でき、プルリクのマージ時にIssueもcloseします。 -->
## 関連Isuue番号
close #52

<!-- 追加、または修正する機能の概要を記述してください。 -->
## 追加・変更の概要
issueに記載

<!-- なぜこの追加・変更が必要なのか目的を記述してください。 -->
## 変更の目的
お店登録画面で登録した電話番号をCoreDataで管理

<!-- 進捗状況をチェックボックスで管理してください。 -->
## タスクの進捗状況
issueに記載

<!-- UIのキャプチャ、APIのリクエスト/レスポンス等、変更内容を明確に記述してください。 -->
## 変更内容
なし

<!-- 影響範囲を予め明確に想定して記述してください。 -->
## 影響範囲
なし

<!-- 追加・変更した機能の操作方法を記述してください。キャプチャや動画を添付してください。 -->
## 操作方法
なし

<!-- テストしたことをリストアップしてください。 -->
## テストしたこと
電話番号をタップして実際に電話をかける機能

<!-- 相談事項や、重点的にレビューしてほしいところを記述してください。 -->
## 相談事項
今回は入力した[電話番号をタップして実際に電話をかけるテスト](https://github.com/Koki2022/Swift-/tree/main/GourmeAppTest/PhoneNumberTest)をしました。
特にハイフンは入力する必要なく、キーボードに電話番号入力用のタイプを指定できました。
今後はAPIから電話番号を取得した際にハイフンの要否がどうなるかを調べる必要がありますが
今後のissueで取り組もうと考えております。今回は入力した電話番号をCoreDataに登録する機能だけ
確認いただければと思います。
